### PR TITLE
Switch SCSS color variables to CSS color variables

### DIFF
--- a/common/color-definitions.scss
+++ b/common/color-definitions.scss
@@ -1,7 +1,0 @@
-
-
- :root {
-  --secondary-hover: #{
-    darken($secondary, 3%)
-    };
-}

--- a/common/color-definitions.scss
+++ b/common/color-definitions.scss
@@ -1,0 +1,6 @@
+
+
+ :root {
+  --secondary-hover: #{
+    darken($secondary, 3%)
+    };

--- a/common/color_definitions.scss
+++ b/common/color_definitions.scss
@@ -1,0 +1,7 @@
+
+:root {
+  --secondary-hover: #{darken($secondary, 3%)};
+  --primary-60-light-or-secondary-40-light: #{dark-light-choose(
+      scale-color($primary, $lightness: 60%), scale-color($secondary, $lightness: 40%)
+    )};
+}

--- a/common/common.scss
+++ b/common/common.scss
@@ -71,7 +71,7 @@
      }
 
     a.title {
-      color: $primary;
+      color: var(--primary);
     }
 
     a.topic-featured-link {
@@ -134,7 +134,7 @@
       max-width: 100%;
       float: left;
       clear: both;
-      
+
       overflow-wrap: break-word;
       word-wrap: break-word;
 
@@ -161,7 +161,7 @@
     grid-area: meta;
 
     .topic-views {
-      color: $primary-medium;
+      color: var(--primary-medium);
     }
 
     .topic-replies span {
@@ -288,7 +288,7 @@ button.list-button {
   }
 
   &.has-like, &.topic-like:not([disabled]):hover {
-    color: $love;
+    color: var(--love);
   }
 
   &.has-like[disabled]:hover {
@@ -301,7 +301,7 @@ button.list-button {
 
   &.bookmarked, &.topic-bookmark:hover {
     i.fa-bookmark, .d-icon-bookmark {
-      color: $tertiary;
+      color: var(--tertiary);
     }
   }
 }
@@ -313,7 +313,7 @@ button.list-button {
 
   &.has-like {
     .fa-heart, .d-icon-heart {
-      color: $love !important;
+      color: var(--love) !important;
     }
   }
 }
@@ -393,10 +393,10 @@ button.list-button {
       .content, .content a {
 
         z-index: 2;
-        color: $secondary;
+        color: var(--secondary);
 
         a.mention {
-          background-color: $primary-high;
+          background-color: var(--primary-high);
         }
 
         img {
@@ -444,7 +444,7 @@ img.select-thumbnail-options:active {
 }
 
 img.select-thumbnail-preview {
-  border: solid 1px $primary-medium;
+  border: solid 1px var(--primary-medium);
   margin: 5px 0px 5px 0px;
   padding: 5px;
   width: 148px;
@@ -464,16 +464,16 @@ img.select-thumbnail-preview {
   margin-left: 2px;
   display: inline-flex;
   cursor: pointer;
-  
-  background-color: $tertiary;
+
+  background-color: var(--tertiary);
 
   label {
-    color: $secondary;
+    color: var(--secondary);
     display: inline-block;
     cursor: pointer;
   }
   svg {
-    color: $secondary;
+    color: var(--secondary);
     display: inline-block;
   }
 

--- a/common/common.scss
+++ b/common/common.scss
@@ -248,7 +248,7 @@ html:not(.tile-style) .topic-actions {
 }
 
 .like-count, .list-vote-count {
-  color: dark-light-choose(scale-color($primary, $lightness: 60%), scale-color($secondary, $lightness: 40%));
+  color: var(--primary-60-light-or-secondary-40-light);
   font-size: 13px;
   display: inline-block;
   vertical-align: bottom;

--- a/common/common.scss
+++ b/common/common.scss
@@ -40,7 +40,7 @@
   }
 
   .tiles-grid-item:hover {
-    background-color: darken($secondary, 2%);
+    background-color: var(--secondary-hover);
     lighten: ($primary, 70%);
   }
 
@@ -478,7 +478,7 @@ img.select-thumbnail-preview {
   }
 
   &:hover {
-    background-color: darken($tertiary, 5%);
+    background-color: var(--tertiary-hover);
   }
 }
 
@@ -487,7 +487,7 @@ img.select-thumbnail-preview {
 }
 
 .tiles-grid-item:hover {
-  background-color: darken($secondary, 3%);
+  background-color: var(--secondary-hover);
   lighten: ($primary, 70%);
 }
 

--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -99,7 +99,7 @@
   }
 
   .tiles-grid-item:hover {
-    background-color: darken($secondary, 2%);
+    background-color: var(--secondary-hover);
     lighten: ($primary, 70%);
   }
 

--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -1,9 +1,9 @@
 .mobile-view .topic-list {
-  
+
   .topic-thumbnail {
     padding: 0;
   }
-  
+
   .topic-details {
     max-height: initial;
     position: relative;
@@ -11,42 +11,42 @@
     min-height: 45px;
     overflow: hidden;
   }
-  
+
   .topic-excerpt {
     max-height: initial;
     width: 100%;
   }
-  
+
   .topic-category {
     margin-top: 6px;
     display: block;
   }
-  
+
   .topic-actions {
     margin-top: 5px;
     float: none;
   }
-  
+
   .list-button {
     font-size: 1em;
     padding: 0 10px 0 0px;
   }
-  
+
   .like-count {
     font-size: 1em;
     line-height: 1em;
     float: left;
     margin-right: 8px;
   }
-  
+
   .list-button i {
     vertical-align: top;
   }
-  
+
   .num.activity {
     float: right;
   }
-  
+
   img.thumbnail:not(.tiles-thumbnail) {
     max-width:80px;
     max-height:80px;
@@ -126,7 +126,7 @@
      }
 
     a.title {
-      color: $primary;
+      color: var(--primary);
     }
 
     a.topic-featured-link {
@@ -241,10 +241,10 @@
     .list-button {
       font-size: 1em;
       padding: 0 0 0 10px;
-      color: $primary-medium;
+      color: var(--primary-medium);
 
       &.has-like, &.topic-like:not([disabled]):hover {
-        color: $love;
+        color: var(--love);
       }
     }
   }


### PR DESCRIPTION
This is about supporting automatic dark mode as explained in https://meta.discourse.org/t/updating-themes-and-plugins-to-support-automatic-dark-mode/161595.

I did one commit, switching SCSS variables to the CSS color properties declared by default in Discourse. 

Another step would be to declare the variables that use darken, lighten and scale-color. The post above suggests to declare them in a dedicated file (color_definitions.scss) as in this commit: https://github.com/discourse/graceful/commit/b44f048cd97bf33b8d3316974844476a25466ee0. Would you want to support automatic color mode in that way? 