### PR TITLE
Replace SCSS color variables with CSS color variables

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -40,8 +40,7 @@
   }
 
   .tiles-grid-item:hover {
-    background-color: darken($secondary, 2%);
-    lighten: ($primary, 70%);
+    background-color: var(--blend-primary-secondary-5);
   }
 
   .tiles-grid-item:active {
@@ -71,7 +70,7 @@
      }
 
     a.title {
-      color: $primary;
+      color: var(--primary);
     }
 
     a.topic-featured-link {
@@ -135,7 +134,7 @@
       float: left;
       clear: both;
       padding-right: 0px;
-      
+
       overflow-wrap: break-word;
       word-wrap: break-word;
 
@@ -162,7 +161,7 @@
     grid-area: meta;
 
     .topic-views {
-      color: $primary-medium;
+      color: var(--primary-medium);
     }
 
     .topic-replies span {
@@ -253,7 +252,7 @@ html:not(.tile-style) .topic-actions {
 }
 
 .like-count, .list-vote-count {
-  color: dark-light-choose(scale-color($primary, $lightness: 60%), scale-color($secondary, $lightness: 40%));
+  color: var(--primary-medium);
   font-size: 13px;
   display: inline-block;
   vertical-align: bottom;
@@ -293,7 +292,7 @@ button.list-button {
   }
 
   &.has-like, &.topic-like:not([disabled]):hover {
-    color: $love;
+    color: var(--love);
   }
 
   &.has-like[disabled]:hover {
@@ -306,7 +305,7 @@ button.list-button {
 
   &.bookmarked, &.topic-bookmark:hover {
     i.fa-bookmark, .d-icon-bookmark {
-      color: $tertiary;
+      color: var(--tertiary);
     }
   }
 }
@@ -318,7 +317,7 @@ button.list-button {
 
   &.has-like {
     .fa-heart, .d-icon-heart {
-      color: $love !important;
+      color: var(--love) !important;
     }
   }
 }
@@ -398,10 +397,10 @@ button.list-button {
       .content, .content a {
 
         z-index: 2;
-        color: $secondary;
+        color: var(--secondary);
 
         a.mention {
-          background-color: $primary-high;
+          background-color: var(--primary-high);
         }
 
         img {
@@ -449,7 +448,7 @@ img.select-thumbnail-options:active {
 }
 
 img.select-thumbnail-preview {
-  border: solid 1px $primary-medium;
+  border: solid 1px var(--primary-medium);
   margin: 5px 0px 5px 0px;
   padding: 5px;
   width: 148px;
@@ -469,21 +468,21 @@ img.select-thumbnail-preview {
   margin-left: 2px;
   display: inline-flex;
   cursor: pointer;
-  
-  background-color: $tertiary;
+
+  background-color: var(--tertiary);
 
   label {
-    color: $secondary;
+    color: var(--secondary);
     display: inline-block;
     cursor: pointer;
   }
   svg {
-    color: $secondary;
+    color: var(--secondary);
     display: inline-block;
   }
 
   &:hover {
-    background-color: darken($tertiary, 5%);
+    background-color: var(--tertiary-hover);
   }
 }
 
@@ -492,8 +491,7 @@ img.select-thumbnail-preview {
 }
 
 .tiles-grid-item:hover {
-  background-color: darken($secondary, 3%);
-  lighten: ($primary, 70%);
+  background-color: var(--blend-primary-secondary-5);
 }
 
 .tiles-grid-item:active {

--- a/mobile/mobile.scss
+++ b/mobile/mobile.scss
@@ -1,9 +1,9 @@
 .mobile-view .topic-list {
-  
+
   .topic-thumbnail {
     padding: 0;
   }
-  
+
   .topic-details {
     max-height: initial;
     position: relative;
@@ -11,42 +11,42 @@
     min-height: 45px;
     overflow: hidden;
   }
-  
+
   .topic-excerpt {
     max-height: initial;
     width: 100%;
   }
-  
+
   .topic-category {
     margin-top: 6px;
     display: block;
   }
-  
+
   .topic-actions {
     margin-top: 5px;
     float: none;
   }
-  
+
   .list-button {
     font-size: 1em;
     padding: 0 10px 0 0px;
   }
-  
+
   .like-count {
     font-size: 1em;
     line-height: 1em;
     float: left;
     margin-right: 8px;
   }
-  
+
   .list-button i {
     vertical-align: top;
   }
-  
+
   .num.activity {
     float: right;
   }
-  
+
   img.thumbnail:not(.tiles-thumbnail) {
     max-width:80px;
     max-height:80px;
@@ -99,8 +99,7 @@
   }
 
   .tiles-grid-item:hover {
-    background-color: darken($secondary, 2%);
-    lighten: ($primary, 70%);
+    background-color: var(--blend-primary-secondary-5);
   }
 
   .tiles-grid-item:active {
@@ -126,7 +125,7 @@
      }
 
     a.title {
-      color: $primary;
+      color: var(--primary);
     }
 
     a.topic-featured-link {
@@ -241,10 +240,10 @@
     .list-button {
       font-size: 1em;
       padding: 0 0 0 10px;
-      color: $primary-medium;
+      color: var(--primary-medium);
 
       &.has-like, &.topic-like:not([disabled]):hover {
-        color: $love;
+        color: var(--love);
       }
     }
   }


### PR DESCRIPTION
Sorry, only got back to this now. I got  several conflicts trying to re-base the other branch, so I just opened a new one now and did one commit with changes to the variables. I'm using this version on our site right now: 
https://community.couchers.org/c/announcements. 
Without the changes, several elements (most notably the topic titles) don't show up correctly. 
For the hover effect on the tiles I just used a default definition from discourse: var(--blend-primary-secondary-5)