### PR TITLE
P08 patch 1

### DIFF
--- a/javascripts/discourse/controllers/tlp-thumbnail-selector.js.es6
+++ b/javascripts/discourse/controllers/tlp-thumbnail-selector.js.es6
@@ -1,4 +1,4 @@
-import { default as computed } from 'ember-addons/ember-computed-decorators';
+import { default as computed } from 'discourse-common/utils/decorators';
 import ModalFunctionality from 'discourse/mixins/modal-functionality';
 import { bufferedProperty } from "discourse/mixins/buffered-content";
 

--- a/javascripts/discourse/initializers/preview-route-edits.js.es6
+++ b/javascripts/discourse/initializers/preview-route-edits.js.es6
@@ -1,7 +1,7 @@
 import { featuredImagesEnabled } from '../lib/tlp-utilities';
 import { ajax } from 'discourse/lib/ajax';
 import { withPluginApi } from 'discourse/lib/plugin-api';
-import PreloadStore from "preload-store";
+import PreloadStore from "discourse/lib/preload-store";
 import CategoryList from "discourse/models/category-list";
 import TopicList from "discourse/models/topic-list";
 import {findOrResetCachedTopicList} from 'discourse/lib/cached-topic-list';


### PR DESCRIPTION
ember-addons/ember-computed-decorators and preload-store are now deprecated.