### PR TITLE
IMPROVE: like icon alignment when no likes

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -273,6 +273,9 @@ html:not(.tile-style) {
   .topic-actions {
     display: block;
     margin-top: 5px;
+    .like-count:empty {
+      margin-right: 0;
+    }
   }
 }
 


### PR DESCRIPTION
Align the heart icon to the left along with the excerpt text if there is no number in front of the like icon.
See https://meta.discourse.org/t/topic-list-previews-theme-component/209973/98?u=canapin