### PR TITLE
Prevent long words from bleeding outside their container

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -268,6 +268,7 @@ html:not(.tile-style) {
 
   .topic-excerpt {
     display: block;
+    word-break: break-word;
   }
 
   .topic-actions {


### PR DESCRIPTION
Prevent long words from the excerpt from bleeding outside their container or stretching the table.
`word-break: break-word` is already used in tiles display, but not in list display.
