### PR TITLE
Fix preview card links and avatar wrapping

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -323,6 +323,7 @@ img.non-tiles-thumbnail {
       align-self: center;
       text-align: right;
       color: var(--primary-med-or-secondary-med);
+      white-space: nowrap;
 
       .avatar {
         padding: 0 0 0 0;

--- a/javascripts/discourse/components/details/previews-excerpt.gjs
+++ b/javascripts/discourse/components/details/previews-excerpt.gjs
@@ -10,11 +10,12 @@ export default class PreviewsExcerpt extends Component {
   }
 
   get destinationUrl() {
-    if (this.args.topic.force_latest_post_nav && this.args.topic.last_post_id) {
-      return `/t/${this.args.topic.slug}/${this.args.topic.id}/${this.args.topic.last_post_id}`;
-    } else {
-      return this.args.topic.url;
-    }
+    const topic = this.args.topic;
+    const topicUrl = topic.linked_post_number
+      ? topic.urlForPostNumber(topic.linked_post_number)
+      : topic.lastUnreadUrl;
+
+    return topicUrl || topic.url;
   }
 
   get excerpt() {

--- a/javascripts/discourse/components/details/previews-excerpt.gjs
+++ b/javascripts/discourse/components/details/previews-excerpt.gjs
@@ -11,9 +11,15 @@ export default class PreviewsExcerpt extends Component {
 
   get destinationUrl() {
     const topic = this.args.topic;
-    const topicUrl = topic.linked_post_number
-      ? topic.urlForPostNumber(topic.linked_post_number)
-      : topic.lastUnreadUrl;
+
+    if (topic.force_latest_post_nav && topic.last_post_id) {
+      return `/t/${topic.slug}/${topic.id}/${topic.last_post_id}`;
+    }
+
+    const topicUrl =
+      topic.linked_post_number && typeof topic.urlForPostNumber === "function"
+        ? topic.urlForPostNumber(topic.linked_post_number)
+        : topic.lastUnreadUrl;
 
     return topicUrl || topic.url;
   }

--- a/javascripts/discourse/components/previews-thumbnail.gjs
+++ b/javascripts/discourse/components/previews-thumbnail.gjs
@@ -41,11 +41,12 @@ export default class PreviewsThumbnail extends Component {
   }
 
   get destinationUrl() {
-    if (this.args.topic.force_latest_post_nav && this.args.topic.last_post_id) {
-      return `/t/${this.args.topic.slug}/${this.args.topic.id}/${this.args.topic.last_post_id}`;
-    } else {
-      return this.args.topic.url;
-    }
+    const topic = this.args.topic;
+    const topicUrl = topic.linked_post_number
+      ? topic.urlForPostNumber(topic.linked_post_number)
+      : topic.lastUnreadUrl;
+
+    return topicUrl || topic.url;
   }
 
   <template>

--- a/javascripts/discourse/components/previews-thumbnail.gjs
+++ b/javascripts/discourse/components/previews-thumbnail.gjs
@@ -42,9 +42,15 @@ export default class PreviewsThumbnail extends Component {
 
   get destinationUrl() {
     const topic = this.args.topic;
-    const topicUrl = topic.linked_post_number
-      ? topic.urlForPostNumber(topic.linked_post_number)
-      : topic.lastUnreadUrl;
+
+    if (topic.force_latest_post_nav && topic.last_post_id) {
+      return `/t/${topic.slug}/${topic.id}/${topic.last_post_id}`;
+    }
+
+    const topicUrl =
+      topic.linked_post_number && typeof topic.urlForPostNumber === "function"
+        ? topic.urlForPostNumber(topic.linked_post_number)
+        : topic.lastUnreadUrl;
 
     return topicUrl || topic.url;
   }


### PR DESCRIPTION
Fixes Issues #57 and #58.

This updates the preview thumbnail and excerpt links so they follow the same destination behavior as Discourse’s normal topic title link, preserving the user’s last unread/read position where available.

It also prevents the participant avatar row from wrapping when 5 avatars are shown in topic preview cards.

The changes are intentionally minimal and limited to the affected preview link components and avatar row styling.

Tested on a Discourse install by temporarily installing this branch as a theme component and confirming:
- topic title, thumbnail, and excerpt links now land at the same last-read/latest-unread position
- 5 participant avatars stay on one row