### PR TITLE
Make blank topic preview tile area clickable

### DIFF
--- a/javascripts/discourse/initializers/preview-edits.gjs
+++ b/javascripts/discourse/initializers/preview-edits.gjs
@@ -41,9 +41,14 @@ const previewsDetails = <template>
 </template>;
 
 function destinationUrl(topic) {
-  const topicUrl = topic.linked_post_number
-    ? topic.urlForPostNumber(topic.linked_post_number)
-    : topic.lastUnreadUrl;
+  if (topic.force_latest_post_nav && topic.last_post_id) {
+    return `/t/${topic.slug}/${topic.id}/${topic.last_post_id}`;
+  }
+
+  const topicUrl =
+    topic.linked_post_number && typeof topic.urlForPostNumber === "function"
+      ? topic.urlForPostNumber(topic.linked_post_number)
+      : topic.lastUnreadUrl;
 
   return topicUrl || topic.url;
 }
@@ -245,12 +250,14 @@ export default apiInitializer("0.8", (api) => {
 
       const result = next();
       const { event, navigateToTopic, topic } = context;
-      const target = event.target;
+      const target = event
+        .composedPath()
+        .find((element) => element instanceof Element);
 
       if (
         event.defaultPrevented ||
         wantsNewWindow(event) ||
-        !(target instanceof Element) ||
+        !target ||
         typeof navigateToTopic !== "function" ||
         target.closest(INTERACTIVE_TILE_SELECTOR)
       ) {

--- a/javascripts/discourse/initializers/preview-edits.gjs
+++ b/javascripts/discourse/initializers/preview-edits.gjs
@@ -1,6 +1,7 @@
 import { trustHTML } from "@ember/template";
 import { apiInitializer } from "discourse/lib/api";
 import { getURLWithCDN } from "discourse/lib/get-url";
+import { wantsNewWindow } from "discourse/lib/intercept-click";
 import loadScript from "discourse/lib/load-script";
 import { resizeAllGridItems } from "../lib/gridupdate";
 import PreviewsDetails from "./../components/previews-details";
@@ -8,6 +9,28 @@ import PreviewsThumbnail from "./../components/previews-thumbnail";
 import PreviewsTilesThumbnail from "./../components/previews-tiles-thumbnail";
 
 const PLUGIN_ID = "discourse-tc-topic-list-previews";
+const INTERACTIVE_TILE_SELECTOR = [
+  "a",
+  "button",
+  "input",
+  "label",
+  "select",
+  "textarea",
+  "[role='button']",
+  "[role='link']",
+  ".avatar",
+  ".badge-category",
+  ".badge-category__wrapper",
+  ".badge-notification",
+  ".badge-posts",
+  ".badge-wrapper",
+  ".discourse-tag",
+  ".discourse-tags",
+  ".topic-actions",
+  ".topic-category",
+  ".topic-status",
+  ".topic-statuses",
+].join(",");
 
 const previewsTilesThumbnail = <template>
   <PreviewsTilesThumbnail @topic={{@topic}} />
@@ -16,6 +39,14 @@ const previewsTilesThumbnail = <template>
 const previewsDetails = <template>
   <PreviewsDetails @topic={{@topic}} />
 </template>;
+
+function destinationUrl(topic) {
+  const topicUrl = topic.linked_post_number
+    ? topic.urlForPostNumber(topic.linked_post_number)
+    : topic.lastUnreadUrl;
+
+  return topicUrl || topic.url;
+}
 
 export default apiInitializer("0.8", (api) => {
   const siteSettings = api.container.lookup("service:site-settings");
@@ -204,6 +235,34 @@ export default apiInitializer("0.8", (api) => {
     }
     return columns;
   });
+
+  api.registerBehaviorTransformer(
+    "topic-list-item-click",
+    ({ next, context }) => {
+      if (!topicListPreviewsService.displayTiles) {
+        return next();
+      }
+
+      const result = next();
+      const { event, navigateToTopic, topic } = context;
+      const target = event.target;
+
+      if (
+        event.defaultPrevented ||
+        wantsNewWindow(event) ||
+        !(target instanceof Element) ||
+        typeof navigateToTopic !== "function" ||
+        target.closest(INTERACTIVE_TILE_SELECTOR)
+      ) {
+        return result;
+      }
+
+      event.preventDefault();
+      navigateToTopic(topic, destinationUrl(topic));
+
+      return result;
+    }
+  );
 
   api.modifyClass("component:search-result-entries", {
     pluginId: PLUGIN_ID,


### PR DESCRIPTION
Fixes #60.

In tile mode, topic preview cards use pointer cursor styling, but clicking blank/non-interactive space inside the tile does not navigate anywhere.

This adds a topic-list-item-click behavior transformer so blank tile space navigates to the same topic destination used by the title link.

The change avoids handling clicks on interactive elements such as links, buttons, inputs, avatars, tags, category links, badges, topic actions, and topic status elements.

Tested on a Discourse install by temporarily installing this branch as a theme component and confirming:
- blank space inside the tile navigates to the topic
- title/image/excerpt links still work
- avatars, tags, category links, badges, and topic actions are not intercepted