### PR TITLE
Fix activity timestamp wrapping in topic preview cards

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -304,6 +304,12 @@ img.non-tiles-thumbnail {
 
         .topic-timing {
           vertical-align: top;
+
+          a {
+            display: inline-flex;
+            align-items: center;
+            white-space: nowrap;
+          }
         }
       }
     }

--- a/common/common.scss
+++ b/common/common.scss
@@ -308,6 +308,7 @@ img.non-tiles-thumbnail {
           a {
             display: inline-flex;
             align-items: center;
+            gap: 0.25em;
             white-space: nowrap;
           }
         }


### PR DESCRIPTION
Fixes #62

This PR fixes a layout regression after the latest Discourse update where the activity timestamp in Topic List Previews could wrap onto two lines, placing the clock icon above the relative time.

The timestamp link is now displayed as an inline flex item, vertically aligned, kept on one line, and given a small relative gap between the icon and text.

Tested on a Discourse install using the same fix in our custom branch.
