### PR TITLE
Prevent topic poster avatars from wrapping

### DIFF
--- a/common/common.scss
+++ b/common/common.scss
@@ -323,6 +323,7 @@ img.non-tiles-thumbnail {
       align-self: center;
       text-align: right;
       color: var(--primary-med-or-secondary-med);
+      white-space: nowrap;
 
       .avatar {
         padding: 0 0 0 0;


### PR DESCRIPTION
This PR extracts the small CSS-only avatar wrapping fix from #59.

It prevents the topic poster/avatar row from wrapping when the maximum number of avatars is shown in a topic preview card.

No link behavior changes are included.
